### PR TITLE
APP-534 Salesforce integration returns 500 when posting not supported event

### DIFF
--- a/integration-commons/src/main/java/org/symphonyoss/integration/entity/MessageMLParseException.java
+++ b/integration-commons/src/main/java/org/symphonyoss/integration/entity/MessageMLParseException.java
@@ -15,4 +15,8 @@ public class MessageMLParseException extends IntegrationRuntimeException {
     super(COMPONENT, message, cause);
   }
 
+  public MessageMLParseException(String message) {
+    super(COMPONENT, message);
+  }
+
 }

--- a/integration-commons/src/main/java/org/symphonyoss/integration/entity/MessageMLParser.java
+++ b/integration-commons/src/main/java/org/symphonyoss/integration/entity/MessageMLParser.java
@@ -58,13 +58,18 @@ public class MessageMLParser {
    */
   public static MessageML parse(String xml) throws JAXBException {
     JAXBContext jaxbContext = JAXBContext.newInstance(MessageML.class);
-    Unmarshaller unmarshaller = null;
+    Unmarshaller unmarshaller;
     unmarshaller = jaxbContext.createUnmarshaller();
 
     StringReader reader = new StringReader(xml);
 
     String presentation = ParserUtils.getPresentationMLContent(xml);
     MessageML messageML = (MessageML) unmarshaller.unmarshal(reader);
+
+    if (messageML.getEntity() == null) {
+      throw new MessageMLParseException("Invalid message format. At least one entity is needed to parse.");
+    }
+
     messageML.getEntity().setPresentationML(presentation);
     return messageML;
   }

--- a/integration-commons/src/test/java/org/symphonyoss/integration/entity/MessageMLParserTest.java
+++ b/integration-commons/src/test/java/org/symphonyoss/integration/entity/MessageMLParserTest.java
@@ -92,6 +92,12 @@ public class MessageMLParserTest {
   }
 
   @Test(expected = MessageMLParseException.class)
+  public void testParseWithoutEntity() throws JAXBException, EntityXMLGeneratorException {
+    String xml = "<messageML>simple message</messageML>";
+    parser.parse(xml);
+  }
+
+  @Test(expected = MessageMLParseException.class)
   public void testNullBody() {
     parser.validate(null);
   }


### PR DESCRIPTION
When sent a message without an entity to Salesforce (or anything that uses MessageMLParser.parse method) it would end up in a NullPointerException as it needs an entity to process the message.
As it should return a BAD_REQUEST since the format sent is invalid, I added a check for that and a unit test to cover this scenario.