### PR TITLE
APP-633: Returning HTTP 415 when the payload content-type is not supported.

### DIFF
--- a/integration-web/src/main/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResource.java
+++ b/integration-web/src/main/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResource.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016-2017 Symphony Integrations - Symphony LLC
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,11 +21,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.symphonyoss.integration.entity.MessageMLParseException;
 import org.symphonyoss.integration.webhook.WebHookIntegration;
 import org.symphonyoss.integration.webhook.WebHookPayload;
@@ -41,117 +37,125 @@ import javax.servlet.http.HttpServletRequest;
 @RestController
 public class WebHookDispatcherResource extends WebHookResource {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(WebHookDispatcherResource.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WebHookDispatcherResource.class);
 
-  /**
-   * Handle HTTP POST requests sent from third-party apps to post messages with Content-type
-   * 'application/x-www-form-urlencoded'
-   * @param hash Configuration instance identifier
-   * @param configurationId Configuration identifier
-   * @param configurationType Configuration type
-   * @param request HTTP request
-   * @return HTTP 200 if success or HTTP error otherwise.
-   */
-  @RequestMapping(value = "/{configurationType}/{configurationId}/{hash}",
-      consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE, method = RequestMethod.POST,
-      produces = MediaType.TEXT_PLAIN_VALUE)
-  public ResponseEntity<String> handleFormRequest(@PathVariable String hash,
-      @PathVariable String configurationId, @PathVariable String configurationType,
-      HttpServletRequest request) {
-    return handleFormRequest(hash, configurationId, request);
-  }
-
-  /**
-   * Handle HTTP POST requests sent from third-party apps to post messages with Content-type
-   * 'application/x-www-form-urlencoded'
-   * @param hash Configuration instance identifier
-   * @param configurationId Configuration identifier
-   * @param request HTTP request
-   * @return HTTP 200 if success or HTTP error otherwise.
-   */
-  @RequestMapping(value = "/{configurationId}/{hash}",
-      consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE, method = RequestMethod.POST,
-      produces = MediaType.TEXT_PLAIN_VALUE)
-  public ResponseEntity<String> handleFormRequest(@PathVariable String hash,
-      @PathVariable String configurationId, HttpServletRequest request) {
-    return handleRequest(hash, configurationId, null, request);
-  }
-
-  /**
-   * Handle HTTP POST requests sent from third-party apps to post messages.
-   * @param hash Configuration instance identifier
-   * @param configurationId Configuration identifier
-   * @param configurationType Configuration type
-   * @param request HTTP request
-   * @return HTTP 200 if success or HTTP error otherwise.
-   */
-  @RequestMapping(value = "/{configurationType}/{configurationId}/{hash}",
-      consumes = MediaType.ALL_VALUE, method = RequestMethod.POST,
-      produces = MediaType.TEXT_PLAIN_VALUE)
-  public ResponseEntity<String> handleRequest(@PathVariable String hash,
-      @PathVariable String configurationId, @PathVariable String configurationType,
-      @RequestBody String body, HttpServletRequest request) {
-    return handleRequest(hash, configurationId, body, request);
-  }
-
-  /**
-   * Handle HTTP POST requests sent from third-party apps to post messages.
-   * @param hash Configuration instance identifier
-   * @param configurationId Configuration identifier
-   * @param request HTTP request
-   * @return HTTP 200 if success or HTTP error otherwise.
-   */
-  @RequestMapping(value = "/{configurationId}/{hash}", consumes = MediaType.ALL_VALUE,
-      method = RequestMethod.POST, produces = MediaType.TEXT_PLAIN_VALUE)
-  public ResponseEntity<String> handleRequest(@PathVariable String hash,
-      @PathVariable String configurationId, @RequestBody String body, HttpServletRequest request) {
-    LOGGER.info("Request received for hash {} and configuration {}", hash, configurationId);
-
-    WebHookIntegration whiIntegration = getWebHookIntegration(configurationId);
-
-    WebHookPayload payload = retrieveWebHookPayload(request, body);
-
-    // handles the request
-    try {
-      String configurationType = whiIntegration.getSettings().getType();
-      whiIntegration.handle(hash, configurationType, payload);
-      return ResponseEntity.ok().body("");
-    } catch (WebHookParseException | MessageMLParseException e) {
-      LOGGER.error(String.format("Couldn't parse the incoming payload for the instance: %s", hash), e);
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-          .body(String.format("Couldn't validate the incoming payload for the instance: %s", hash));
+    /**
+     * Handle HTTP POST requests sent from third-party apps to post messages with Content-type
+     * 'application/x-www-form-urlencoded'
+     * @param hash Configuration instance identifier
+     * @param configurationId Configuration identifier
+     * @param configurationType Configuration type
+     * @param request HTTP request
+     * @return HTTP 200 if success or HTTP error otherwise.
+     */
+    @RequestMapping(value = "/{configurationType}/{configurationId}/{hash}",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE, method = RequestMethod.POST,
+            produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> handleFormRequest(@PathVariable String hash,
+                                                    @PathVariable String configurationId, @PathVariable String configurationType,
+                                                    HttpServletRequest request) {
+        return handleFormRequest(hash, configurationId, request);
     }
-  }
 
-  /**
-   * Handle HTTP HEAD requests sent from third-party apps
-   * @param hash Configuration instance identifier
-   * @param configurationId Configuration identifier
-   * @param configurationType Configuration type
-   * @return HTTP 200 if success or HTTP error otherwise.
-   */
-  @RequestMapping(value = "/{configurationType}/{configurationId}/{hash}", method = RequestMethod.HEAD)
-  public ResponseEntity<Void> handleHeadRequest(@PathVariable String hash,
-      @PathVariable String configurationId, @PathVariable String configurationType) {
-    return handleHeadRequest(hash, configurationId);
-  }
+    /**
+     * Handle HTTP POST requests sent from third-party apps to post messages with Content-type
+     * 'application/x-www-form-urlencoded'
+     * @param hash Configuration instance identifier
+     * @param configurationId Configuration identifier
+     * @param request HTTP request
+     * @return HTTP 200 if success or HTTP error otherwise.
+     */
+    @RequestMapping(value = "/{configurationId}/{hash}",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE, method = RequestMethod.POST,
+            produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> handleFormRequest(@PathVariable String hash,
+                                                    @PathVariable String configurationId, HttpServletRequest request) {
+        return handleRequest(hash, configurationId, null, request);
+    }
 
-  /**
-   * Handle HTTP HEAD requests sent from third-party apps
-   * @param hash Configuration instance identifier
-   * @param configurationId Configuration identifier
-   * @return HTTP 200 if success or HTTP error otherwise.
-   */
-  @RequestMapping(value = "/{configurationId}/{hash}", method = RequestMethod.HEAD)
-  public ResponseEntity<Void> handleHeadRequest(@PathVariable String hash,
-      @PathVariable String configurationId) {
-    LOGGER.info("HEAD Request received for hash {} and configuration {}", hash, configurationId);
+    /**
+     * Handle HTTP POST requests sent from third-party apps to post messages.
+     * @param hash Configuration instance identifier
+     * @param configurationId Configuration identifier
+     * @param configurationType Configuration type
+     * @param request HTTP request
+     * @return HTTP 200 if success or HTTP error otherwise.
+     */
+    @RequestMapping(value = "/{configurationType}/{configurationId}/{hash}",
+            consumes = MediaType.ALL_VALUE, method = RequestMethod.POST,
+            produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> handleRequest(@PathVariable String hash,
+                                                @PathVariable String configurationId, @PathVariable String configurationType,
+                                                @RequestBody String body, HttpServletRequest request) {
+        return handleRequest(hash, configurationId, body, request);
+    }
 
-    WebHookIntegration webHookIntegration = getWebHookIntegration(configurationId);
+    /**
+     * Handle HTTP POST requests sent from third-party apps to post messages.
+     * @param hash Configuration instance identifier
+     * @param configurationId Configuration identifier
+     * @param request HTTP request
+     * @return HTTP 200 if success or HTTP error otherwise.
+     */
+    @RequestMapping(value = "/{configurationId}/{hash}", consumes = MediaType.ALL_VALUE,
+            method = RequestMethod.POST, produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<String> handleRequest(@PathVariable String hash,
+                                                @PathVariable String configurationId, @RequestBody String body, HttpServletRequest request) {
+        LOGGER.info("Request received for hash {} and configuration {}", hash, configurationId);
 
-    String configurationType = webHookIntegration.getSettings().getType();
-    getConfigurationInstance(hash, configurationId, configurationType);
+        WebHookIntegration whiIntegration = getWebHookIntegration(configurationId);
 
-    return ResponseEntity.ok().build();
-  }
+        WebHookPayload payload = retrieveWebHookPayload(request, body);
+
+        // Checks if the payload has the correct content type
+        if (!whiIntegration.isSupportedContentType(payload.getContentType())) {
+            String msg = String.format("Unsupported Content-Type [%s]. Accept %s", payload.getContentType(),
+                    whiIntegration.getSupportedContentTypes());
+            LOGGER.error(msg);
+            return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE).body(msg);
+        }
+
+        // handles the request
+        try {
+            String configurationType = whiIntegration.getSettings().getType();
+            whiIntegration.handle(hash, configurationType, payload);
+            return ResponseEntity.ok().body("");
+        } catch (WebHookParseException | MessageMLParseException e) {
+            LOGGER.error(String.format("Couldn't parse the incoming payload for the instance: %s", hash), e);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(String.format("Couldn't validate the incoming payload for the instance: %s", hash));
+        }
+    }
+
+    /**
+     * Handle HTTP HEAD requests sent from third-party apps
+     * @param hash Configuration instance identifier
+     * @param configurationId Configuration identifier
+     * @param configurationType Configuration type
+     * @return HTTP 200 if success or HTTP error otherwise.
+     */
+    @RequestMapping(value = "/{configurationType}/{configurationId}/{hash}", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> handleHeadRequest(@PathVariable String hash,
+                                                  @PathVariable String configurationId, @PathVariable String configurationType) {
+        return handleHeadRequest(hash, configurationId);
+    }
+
+    /**
+     * Handle HTTP HEAD requests sent from third-party apps
+     * @param hash Configuration instance identifier
+     * @param configurationId Configuration identifier
+     * @return HTTP 200 if success or HTTP error otherwise.
+     */
+    @RequestMapping(value = "/{configurationId}/{hash}", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> handleHeadRequest(@PathVariable String hash,
+                                                  @PathVariable String configurationId) {
+        LOGGER.info("HEAD Request received for hash {} and configuration {}", hash, configurationId);
+
+        WebHookIntegration webHookIntegration = getWebHookIntegration(configurationId);
+
+        String configurationType = webHookIntegration.getSettings().getType();
+        getConfigurationInstance(hash, configurationId, configurationType);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/integration-web/src/test/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResourceTest.java
+++ b/integration-web/src/test/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResourceTest.java
@@ -51,11 +51,11 @@ import org.symphonyoss.integration.webhook.exception.WebHookDisabledException;
 import org.symphonyoss.integration.webhook.exception.WebHookParseException;
 import org.symphonyoss.integration.webhook.exception.WebHookUnavailableException;
 
-import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 /**
@@ -132,11 +132,11 @@ public class WebHookDispatcherResourceTest extends WebHookResourceTest {
     supportedFormats.add(MediaType.APPLICATION_JSON_TYPE);
 
     doThrow(WebHookParseException.class).when(whiIntegration)
-            .handle(anyString(), anyString(), any(WebHookPayload.class));
+        .handle(anyString(), anyString(), any(WebHookPayload.class));
     doReturn(supportedFormats).when(whiIntegration).getSupportedContentTypes();
 
     ResponseEntity response = webHookDispatcherResource.handleRequest(
-            TEST_HASH, CONFIGURATION_ID, TEST_USER, MESSAGE_BODY, request);
+        TEST_HASH, CONFIGURATION_ID, TEST_USER, MESSAGE_BODY, request);
 
     assertEquals(HttpStatus.UNSUPPORTED_MEDIA_TYPE, response.getStatusCode());
   }
@@ -156,8 +156,10 @@ public class WebHookDispatcherResourceTest extends WebHookResourceTest {
     doReturn(true).when(whiIntegration).isSupportedContentType(MediaType.WILDCARD_TYPE);
 
     assertEquals(
-        ResponseEntity.badRequest().body("Couldn't validate the incoming payload for the instance: " + TEST_HASH),
-        webHookDispatcherResource.handleRequest(TEST_HASH, CONFIGURATION_ID, TEST_USER, MESSAGE_BODY, request));
+        ResponseEntity.badRequest()
+            .body("Couldn't validate the incoming payload for the instance: " + TEST_HASH),
+        webHookDispatcherResource.handleRequest(TEST_HASH, CONFIGURATION_ID, TEST_USER,
+            MESSAGE_BODY, request));
   }
 
   /**
@@ -363,4 +365,36 @@ public class WebHookDispatcherResourceTest extends WebHookResourceTest {
     Assert.assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
   }
 
+  /**
+   * Test an HTTP Internal Server Error caused by {@link RemoteApiException}
+   */
+  @Test
+  public void testInternalServerErrorWithRemoteApiException() {
+    RemoteApiException ex =
+        new RemoteApiException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), "test");
+    Assert.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR,
+        webHookDispatcherResource.handleRemoteAPIException(ex).getStatusCode());
+  }
+
+  /**
+   * Test an HTTP Bad Request caused by {@link RemoteApiException}
+   */
+  @Test
+  public void testBadRequestWithRemoteApiException() {
+    RemoteApiException ex =
+        new RemoteApiException(Response.Status.BAD_REQUEST.getStatusCode(), "test");
+    Assert.assertEquals(HttpStatus.BAD_REQUEST,
+        webHookDispatcherResource.handleRemoteAPIException(ex).getStatusCode());
+  }
+
+  /**
+   * Test an HTTP Not Found caused by {@link RemoteApiException}
+   */
+  @Test
+  public void testNotFoundWithRemoteApiExceptionThenReturnNotFound() {
+    RemoteApiException ex =
+        new RemoteApiException(Response.Status.NOT_FOUND.getStatusCode(), "test");
+    Assert.assertEquals(HttpStatus.NOT_FOUND,
+        webHookDispatcherResource.handleRemoteAPIException(ex).getStatusCode());
+  }
 }


### PR DESCRIPTION
When a content-type is not support we return now a HTTP 415 describing which types are supported.