### PR TITLE
APP-985 memory leak

### DIFF
--- a/integration-auth/pom.xml
+++ b/integration-auth/pom.xml
@@ -17,6 +17,12 @@
             <artifactId>integration-auth-api-client</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.connectors</groupId>
+            <artifactId>jersey-apache-connector</artifactId>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/integration-auth/src/main/java/org/symphonyoss/integration/authentication/AuthenticationProxyImpl.java
+++ b/integration-auth/src/main/java/org/symphonyoss/integration/authentication/AuthenticationProxyImpl.java
@@ -31,6 +31,7 @@ import org.symphonyoss.integration.exception.authentication.ConnectivityExceptio
 import org.symphonyoss.integration.exception.authentication.ForbiddenAuthException;
 import org.symphonyoss.integration.exception.authentication.UnauthorizedUserException;
 import org.symphonyoss.integration.exception.authentication.UnexpectedAuthException;
+import org.symphonyoss.integration.model.yaml.IntegrationProperties;
 
 import java.security.KeyStore;
 import java.util.Map;
@@ -64,6 +65,9 @@ public class AuthenticationProxyImpl implements AuthenticationProxy {
   private AuthenticationApiClient keyManagerAuthApi;
 
   private Map<String, AuthenticationContext> authContexts = new ConcurrentHashMap<>();
+
+  @Autowired
+  private IntegrationProperties properties;
 
   @Autowired
   private PodAuthHttpApiClient podAuthHttpApiClient;
@@ -261,7 +265,7 @@ public class AuthenticationProxyImpl implements AuthenticationProxy {
    */
   @Override
   public void registerUser(String userId, KeyStore keyStore, String keyStorePass) {
-    authContexts.put(userId, new AuthenticationContext(userId, keyStore, keyStorePass));
+    authContexts.put(userId, new AuthenticationContext(userId, keyStore, keyStorePass, properties.getApiClientConfig()));
   }
 
   /**

--- a/integration-auth/src/test/java/org/symphonyoss/integration/authentication/AuthenticationContextTest.java
+++ b/integration-auth/src/test/java/org/symphonyoss/integration/authentication/AuthenticationContextTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright 2016-2017 Symphony Integrations - Symphony LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.symphonyoss.integration.authentication;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.symphonyoss.integration.exception.RemoteApiException;
+
+/**
+ * Unit test for {@link AuthenticationContext}
+ * Created by Evandro Carrenho on 21/04/17.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AuthenticationContextTest {
+  private static final String SESSION_TOKEN1 = "S-TOKEN-1";
+
+  private static final String KM_TOKEN1 = "KM-TOKEN-1";
+
+  private static final String SESSION_TOKEN2 = "S-TOKEN-2";
+
+  private static final String KM_TOKEN2 = "KM-TOKEN-2";
+
+  private static final String SESSION_TOKEN3 = "S-TOKEN-3";
+
+  private static final String KM_TOKEN3 = "KM-TOKEN-3";
+
+  private static final AuthenticationToken AUTH_TOKEN1 = new AuthenticationToken(SESSION_TOKEN1, KM_TOKEN1);
+
+  private static final AuthenticationToken AUTH_TOKEN2 = new AuthenticationToken(SESSION_TOKEN2, KM_TOKEN2);
+
+  private static final AuthenticationToken AUTH_TOKEN3 = new AuthenticationToken(SESSION_TOKEN3, KM_TOKEN3);
+
+  private static final String USER_ID = "jiraWebHookIntegration";
+
+  private AuthenticationContext authContext;
+
+  @Before
+  public void initAuthenticationContext() {
+    authContext = new AuthenticationContext(USER_ID, null, null);
+  }
+
+  @Test
+  public void testInitialState() throws RemoteApiException {
+    assertEquals(USER_ID, authContext.getUserId());
+    assertEquals(AuthenticationToken.VOID_AUTH_TOKEN, authContext.getToken());
+    assertEquals(AuthenticationToken.VOID_AUTH_TOKEN, authContext.getPreviousToken());
+    assertFalse(authContext.isAuthenticated());
+    assertNotNull(authContext.httpClientForContext());
+  }
+
+  @Test
+  public void testSetToken() throws RemoteApiException {
+    authContext.setToken(AUTH_TOKEN1);
+    assertEquals(USER_ID, authContext.getUserId());
+    assertEquals(AUTH_TOKEN1, authContext.getToken());
+    assertEquals(AuthenticationToken.VOID_AUTH_TOKEN, authContext.getPreviousToken());
+    assertTrue(authContext.isAuthenticated());
+    assertNotNull(authContext.httpClientForContext());
+  }
+
+  @Test
+  public void testChangeToken() throws RemoteApiException {
+    testSetToken();
+    authContext.setToken(AUTH_TOKEN2);
+    assertEquals(USER_ID, authContext.getUserId());
+    assertEquals(AUTH_TOKEN2, authContext.getToken());
+    assertEquals(AUTH_TOKEN1, authContext.getPreviousToken());
+    assertTrue(authContext.isAuthenticated());
+    assertNotNull(authContext.httpClientForContext());
+  }
+
+  @Test
+  public void testChangeTokenTwice() throws RemoteApiException {
+    testChangeToken();
+    authContext.setToken(AUTH_TOKEN3);
+    assertEquals(USER_ID, authContext.getUserId());
+    assertEquals(AUTH_TOKEN3, authContext.getToken());
+    assertEquals(AUTH_TOKEN2, authContext.getPreviousToken());
+    assertTrue(authContext.isAuthenticated());
+    assertNotNull(authContext.httpClientForContext());
+  }
+
+  @Test
+  public void testInvalidateAuthentication() throws RemoteApiException {
+    testChangeToken();
+    authContext.invalidateAuthentication();
+    assertEquals(USER_ID, authContext.getUserId());
+    assertEquals(AUTH_TOKEN2, authContext.getToken());
+    assertEquals(AUTH_TOKEN1, authContext.getPreviousToken());
+    assertFalse(authContext.isAuthenticated());
+    assertNotNull(authContext.httpClientForContext());
+  }
+
+  @Test
+  public void testSetVoidToken() throws RemoteApiException {
+    testChangeToken();
+    authContext.setToken(AuthenticationToken.VOID_AUTH_TOKEN);
+    assertEquals(USER_ID, authContext.getUserId());
+    assertEquals(AUTH_TOKEN2, authContext.getToken());
+    assertEquals(AUTH_TOKEN1, authContext.getPreviousToken());
+    assertFalse(authContext.isAuthenticated());
+    assertNotNull(authContext.httpClientForContext());
+  }
+
+  @Test
+  public void testSetNullToken() throws RemoteApiException {
+    testChangeToken();
+    authContext.setToken(null);
+    assertEquals(USER_ID, authContext.getUserId());
+    assertEquals(AUTH_TOKEN2, authContext.getToken());
+    assertEquals(AUTH_TOKEN1, authContext.getPreviousToken());
+    assertFalse(authContext.isAuthenticated());
+    assertNotNull(authContext.httpClientForContext());
+  }
+  
+}

--- a/integration-auth/src/test/java/org/symphonyoss/integration/authentication/AuthenticationProxyImplTest.java
+++ b/integration-auth/src/test/java/org/symphonyoss/integration/authentication/AuthenticationProxyImplTest.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.glassfish.jersey.apache.connector.ApacheClientProperties;
+import org.glassfish.jersey.client.ClientProperties;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,6 +47,7 @@ import org.symphonyoss.integration.model.yaml.IntegrationProperties;
 
 import java.security.KeyStore;
 
+import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.Response;
 
 /**
@@ -89,6 +93,9 @@ public class AuthenticationProxyImplTest {
 
   @Mock
   private AuthenticationApiClient keyManagerAuthApi;
+
+  @Autowired
+  private IntegrationProperties properties;
 
   @InjectMocks
   @Autowired
@@ -162,6 +169,20 @@ public class AuthenticationProxyImplTest {
     assertTrue(proxy.isAuthenticated(SIMPLEWEBHOOK));
     assertEquals(sessionToken2.getToken(), proxy.getToken(SIMPLEWEBHOOK).getSessionToken());
     assertEquals(kmToken2.getToken(), proxy.getToken(SIMPLEWEBHOOK).getKeyManagerToken());
+
+    // Makes sure the API client configuration has been read properly from the application.yaml file on test resources.
+    Configuration clientConfiguration = proxy.httpClientForUser(JIRAWEBHOOK).getConfiguration();
+    Long clientReadTimeout = (Long) clientConfiguration.getProperty(ClientProperties.READ_TIMEOUT);
+    Long clientConnectTimeout = (Long) clientConfiguration.getProperty(ClientProperties.CONNECT_TIMEOUT);
+    PoolingHttpClientConnectionManager connectionManager = (PoolingHttpClientConnectionManager)
+        clientConfiguration.getProperty(ApacheClientProperties.CONNECTION_MANAGER);
+    Integer clientTotalConn = connectionManager.getMaxTotal();
+    Integer clientTotalConnPerRoute = connectionManager.getDefaultMaxPerRoute();
+
+    assertEquals(properties.getApiClientConfig().getReadTimeout(), clientReadTimeout);
+    assertEquals(properties.getApiClientConfig().getConnectTimeout(), clientConnectTimeout);
+    assertEquals(properties.getApiClientConfig().getMaxConnections(), clientTotalConn);
+    assertEquals(properties.getApiClientConfig().getMaxConnectionsPerRoute(), clientTotalConnPerRoute);
   }
 
   @Test

--- a/integration-auth/src/test/java/org/symphonyoss/integration/authentication/AuthenticationProxyImplTest.java
+++ b/integration-auth/src/test/java/org/symphonyoss/integration/authentication/AuthenticationProxyImplTest.java
@@ -90,12 +90,6 @@ public class AuthenticationProxyImplTest {
   @Mock
   private AuthenticationApiClient keyManagerAuthApi;
 
-  @Mock
-  private KeyStore jiraKs;
-
-  @Mock
-  private KeyStore simpleKs;
-
   @InjectMocks
   @Autowired
   private AuthenticationProxyImpl proxy;
@@ -107,8 +101,8 @@ public class AuthenticationProxyImplTest {
 
   @Before
   public void setup() {
-    this.proxy.registerUser(JIRAWEBHOOK, jiraKs, "");
-    this.proxy.registerUser(SIMPLEWEBHOOK, simpleKs, "");
+    this.proxy.registerUser(JIRAWEBHOOK, null, "");
+    this.proxy.registerUser(SIMPLEWEBHOOK, null, "");
 
     sessionToken.setName("sessionToken");
     sessionToken.setToken(SESSION_TOKEN);

--- a/integration-auth/src/test/resources/application.yaml
+++ b/integration-auth/src/test/resources/application.yaml
@@ -1,4 +1,14 @@
 #
+# API Client configurations
+#
+api_client_config:
+  connect_timeout: 1003
+  read_timeout: 2004
+  max_connections: 57
+  max_connections_per_route: 19
+
+
+#
 # Indicate the host and port for the Symphony POD the Apps are associated with.
 #
 pod:

--- a/integration-provisioning/pom.xml
+++ b/integration-provisioning/pom.xml
@@ -16,8 +16,6 @@
         <spring.boot.version>1.5.1.RELEASE</spring.boot.version>
         <bouncycastle.version>1.51</bouncycastle.version>
         <commons.codec.version>1.10</commons.codec.version>
-        <jersey.common.version>2.12</jersey.common.version>
-
 
         <!-- Override RPM properties -->
         <rpm.name>integration-provisioning</rpm.name>
@@ -86,7 +84,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
-            <version>${jersey.common.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,35 @@
             </modules>
         </profile>
 
+        <profile>
+            <id>Artifactory</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>symphonyArtifactory</name>
+                    <value>true</value>
+                </property>
+            </activation>
+
+            <repositories>
+                <repository>
+                    <id>symphony</id>
+                    <name>symphony releases</name>
+                    <url>https://repo.symphony.com/artifactory/libs-release</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>snapshots</id>
+                    <url>https://repo.symphony.com/artifactory/libs-snapshot</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                </repository>
+            </repositories>
+        </profile>
+
     </profiles>
 
 </project>


### PR DESCRIPTION
Due to memory leaks on the Jersey Client usage, the following has been applied with Apache connectors:
- Connection and read timeouts.
- Connection Pools.