### PR TITLE
APP-1206 Default cache timeout to persist the pod certificate

### DIFF
--- a/integration-web/src/main/resources/application.yml
+++ b/integration-web/src/main/resources/application.yml
@@ -55,3 +55,8 @@ key_manager:
 management:
   security:
     enabled: false
+
+#
+# Time (in minutes) to persist in a local cache the pod certificate to check JWT signature
+#
+public_pod_certificate_cache_duration: 60


### PR DESCRIPTION
- Define time (in  minutes) to persist in a local cache the pod certificate to check JWT signature