### PR TITLE
APP-1206 Fix Provisioning YAML config file

### DIFF
--- a/integration-provisioning/src/main/resources/application.yml
+++ b/integration-provisioning/src/main/resources/application.yml
@@ -13,3 +13,8 @@ server:
 spring:
   profiles:
     active: jira, github, salesforce, universal, trello, zapier
+
+#
+# Time (in minutes) to persist in a local cache the pod certificate to check JWT signature
+#
+public_pod_certificate_cache_duration: 60


### PR DESCRIPTION
- Missing default config for caching pod certificate is causing NullPointerException on the Provisioning Tool.