### PR TITLE
APP-1292 - Sending an incomplete or malformed to Universal Webhook returns the wrong status code

### DIFF
--- a/integration-web/src/main/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResource.java
+++ b/integration-web/src/main/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResource.java
@@ -233,6 +233,7 @@ public class WebHookDispatcherResource extends WebHookResource {
 
   @ExceptionHandler(RemoteApiException.class)
   public ResponseEntity<String> handleRemoteApiException(RemoteApiException e) {
+    LOGGER.error(e.getMessage(), e);
     return ResponseEntity.status(e.getCode()).body(e.getMessage());
   }
 

--- a/integration-web/src/main/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResource.java
+++ b/integration-web/src/main/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResource.java
@@ -37,7 +37,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.symphonyoss.integration.entity.MessageMLParseException;
 import org.symphonyoss.integration.exception.RemoteApiException;
 import org.symphonyoss.integration.logging.LogMessageSource;
-import org.symphonyoss.integration.model.ErrorResponse;
 import org.symphonyoss.integration.webhook.WebHookIntegration;
 import org.symphonyoss.integration.webhook.WebHookPayload;
 import org.symphonyoss.integration.webhook.exception.WebHookParseException;
@@ -233,7 +232,7 @@ public class WebHookDispatcherResource extends WebHookResource {
   }
 
   @ExceptionHandler(RemoteApiException.class)
-  private ResponseEntity<String> handleRemoteApiException(RemoteApiException e) {
+  public ResponseEntity<String> handleRemoteApiException(RemoteApiException e) {
     return ResponseEntity.status(e.getCode()).body(e.getMessage());
   }
 

--- a/integration-web/src/main/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResource.java
+++ b/integration-web/src/main/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResource.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.symphonyoss.integration.entity.MessageMLParseException;
 import org.symphonyoss.integration.exception.RemoteApiException;
 import org.symphonyoss.integration.logging.LogMessageSource;
+import org.symphonyoss.integration.model.ErrorResponse;
 import org.symphonyoss.integration.webhook.WebHookIntegration;
 import org.symphonyoss.integration.webhook.WebHookPayload;
 import org.symphonyoss.integration.webhook.exception.WebHookParseException;
@@ -228,6 +230,11 @@ public class WebHookDispatcherResource extends WebHookResource {
     payload.addParameter(DATA, data);
 
     return handleRequest(hash, configurationId, whiIntegration, payload);
+  }
+
+  @ExceptionHandler(RemoteApiException.class)
+  private ResponseEntity<String> handleRemoteApiException(RemoteApiException e) {
+    return ResponseEntity.status(e.getCode()).body(e.getMessage());
   }
 
 }

--- a/integration-web/src/test/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResourceTest.java
+++ b/integration-web/src/test/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResourceTest.java
@@ -394,6 +394,6 @@ public class WebHookDispatcherResourceTest extends WebHookResourceTest {
     ResponseEntity<String> expected = ResponseEntity.status(errorCode).body(e.getMessage());
     ResponseEntity response = webHookDispatcherResource.handleRemoteApiException(e);
 
-    Assert.assertEquals(expected,response);
+    assertEquals(expected,response);
   }
 }

--- a/integration-web/src/test/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResourceTest.java
+++ b/integration-web/src/test/java/org/symphonyoss/integration/web/resource/WebHookDispatcherResourceTest.java
@@ -384,4 +384,16 @@ public class WebHookDispatcherResourceTest extends WebHookResourceTest {
 
     assertEquals(HttpStatus.UNSUPPORTED_MEDIA_TYPE, response.getStatusCode());
   }
+
+  @Test
+  public void testRemoteApiExceptionHandler() {
+    int errorCode = -1;
+    String errorMessage = "errorMessage";
+    RemoteApiException e = new RemoteApiException(errorCode,errorMessage);
+
+    ResponseEntity<String> expected = ResponseEntity.status(errorCode).body(e.getMessage());
+    ResponseEntity response = webHookDispatcherResource.handleRemoteApiException(e);
+
+    Assert.assertEquals(expected,response);
+  }
 }


### PR DESCRIPTION
RemoteApiExceptions weren't being properly handled on the WebHookDispatcherResource, I've added an exception handler to this class, however if in the future we discover more exceptions are not being handled I believe a whole exceptionHandler class should be made.