### PR TITLE
APP-1687 - Changed Health Check service for KMAuth and PodSessionManager

### DIFF
--- a/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/AgentHealthIndicator.java
+++ b/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/AgentHealthIndicator.java
@@ -20,8 +20,6 @@ import com.github.zafarkhaja.semver.Version;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.symphonyoss.integration.authentication.api.enums.ServiceName;
-import org.symphonyoss.integration.event.MessageMLVersionUpdatedEventData;
-import org.symphonyoss.integration.model.message.MessageMLVersion;
 
 /**
  * Service health indicator for Agent.

--- a/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/CompositeServiceHealthIndicator.java
+++ b/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/CompositeServiceHealthIndicator.java
@@ -45,7 +45,7 @@ public class CompositeServiceHealthIndicator extends CompositeHealthIndicator {
   @PostConstruct
   public void init() {
     for (ServiceHealthIndicator indicator : serviceHealthIndicators) {
-      addHealthIndicator(indicator.getServiceName().toString(), indicator);
+      addHealthIndicator(indicator.mountUserFriendlyServiceName(), indicator);
     }
   }
 

--- a/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/KmAuthHealthIndicator.java
+++ b/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/KmAuthHealthIndicator.java
@@ -14,7 +14,6 @@ import org.symphonyoss.integration.authentication.api.enums.ServiceName;
 public class KmAuthHealthIndicator extends AuthenticationServiceHealthIndicator {
 
   private static final String SERVICE_FIELD = "keyauth";
-  public static final String FRIENDLY_SERVICE_NAME = "Key Manager Auth";
 
   @Override
   protected ServiceName getServiceName() {
@@ -23,7 +22,7 @@ public class KmAuthHealthIndicator extends AuthenticationServiceHealthIndicator 
 
   @Override
   protected String getFriendlyServiceName() {
-    return FRIENDLY_SERVICE_NAME;
+    return ServiceName.KEY_MANAGER_AUTH.toString();
   }
 
   @Override

--- a/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/KmAuthHealthIndicator.java
+++ b/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/KmAuthHealthIndicator.java
@@ -14,10 +14,16 @@ import org.symphonyoss.integration.authentication.api.enums.ServiceName;
 public class KmAuthHealthIndicator extends AuthenticationServiceHealthIndicator {
 
   private static final String SERVICE_FIELD = "keyauth";
+  public static final String FRIENDLY_SERVICE_NAME = "Key Manager Auth";
 
   @Override
   protected ServiceName getServiceName() {
-    return ServiceName.KEY_MANAGER_AUTH;
+    return ServiceName.POD;
+  }
+
+  @Override
+  protected String getFriendlyServiceName() {
+    return FRIENDLY_SERVICE_NAME;
   }
 
   @Override

--- a/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/PodSessionManagerHealthIndicator.java
+++ b/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/PodSessionManagerHealthIndicator.java
@@ -30,7 +30,6 @@ import org.symphonyoss.integration.authentication.api.enums.ServiceName;
 public class PodSessionManagerHealthIndicator extends AuthenticationServiceHealthIndicator {
 
   private static final String SERVICE_FIELD = "sessionauth";
-  public static final String FRIENDLY_SERVICE_NAME = "Pod Session Manager";
 
   @Override
   protected ServiceName getServiceName() {
@@ -38,7 +37,9 @@ public class PodSessionManagerHealthIndicator extends AuthenticationServiceHealt
   }
 
   @Override
-  protected String getFriendlyServiceName() { return FRIENDLY_SERVICE_NAME; }
+  protected String getFriendlyServiceName() {
+    return ServiceName.POD_SESSION_MANAGER.toString();
+  }
 
   @Override
   protected String getMinVersion() {

--- a/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/PodSessionManagerHealthIndicator.java
+++ b/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/PodSessionManagerHealthIndicator.java
@@ -30,11 +30,15 @@ import org.symphonyoss.integration.authentication.api.enums.ServiceName;
 public class PodSessionManagerHealthIndicator extends AuthenticationServiceHealthIndicator {
 
   private static final String SERVICE_FIELD = "sessionauth";
+  public static final String FRIENDLY_SERVICE_NAME = "Pod Session Manager";
 
   @Override
   protected ServiceName getServiceName() {
-    return ServiceName.POD_SESSION_MANAGER;
+    return ServiceName.POD;
   }
+
+  @Override
+  protected String getFriendlyServiceName() { return FRIENDLY_SERVICE_NAME; }
 
   @Override
   protected String getMinVersion() {

--- a/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/ServiceHealthIndicator.java
+++ b/integration-healthcheck/src/main/java/org/symphonyoss/integration/healthcheck/services/ServiceHealthIndicator.java
@@ -323,10 +323,7 @@ public abstract class ServiceHealthIndicator implements HealthIndicator {
    * @return Friendly service name
    */
   protected String getFriendlyServiceName() {
-    String serviceName = getServiceName().toString();
-    serviceName = StringUtils.lowerCase(serviceName);
-    serviceName = StringUtils.replace(serviceName, "_", " ");
-    return  StringUtils.capitalize(serviceName);
+    return getServiceName().toString();
   }
 
   /**

--- a/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/KmAuthHealthIndicatorTest.java
+++ b/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/KmAuthHealthIndicatorTest.java
@@ -30,7 +30,7 @@ public class KmAuthHealthIndicatorTest {
 
   private static final String MOCK_VERSION = "1.48.0";
 
-  private static final ServiceName SERVICE_NAME = ServiceName.KEY_MANAGER_AUTH;
+  private static final String SERVICE_NAME = "Key Manager Auth";
 
   private static final String SERVICE_FIELD = "keyauth";
 
@@ -64,7 +64,7 @@ public class KmAuthHealthIndicatorTest {
 
   @Test
   public void testServiceName() {
-    assertEquals(SERVICE_NAME, indicator.getServiceName());
+    assertEquals(SERVICE_NAME, indicator.mountUserFriendlyServiceName());
   }
 
   @Test

--- a/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/KmAuthHealthIndicatorTest.java
+++ b/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/KmAuthHealthIndicatorTest.java
@@ -30,7 +30,7 @@ public class KmAuthHealthIndicatorTest {
 
   private static final String MOCK_VERSION = "1.48.0";
 
-  private static final String SERVICE_NAME = "Key Manager Auth";
+  private static final String SERVICE_NAME = ServiceName.KEY_MANAGER_AUTH.toString();
 
   private static final String SERVICE_FIELD = "keyauth";
 

--- a/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/PodSessionManagerHealthIndicatorTest.java
+++ b/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/PodSessionManagerHealthIndicatorTest.java
@@ -48,7 +48,7 @@ public class PodSessionManagerHealthIndicatorTest {
 
   private static final String MOCK_VERSION = "1.48.0";
 
-  private static final ServiceName SERVICE_NAME = ServiceName.POD_SESSION_MANAGER;
+  private static final String SERVICE_NAME = "Pod Session Manager";
 
   private static final String POD_SERVICE_NAME = ServiceName.POD.toString();
 
@@ -82,7 +82,7 @@ public class PodSessionManagerHealthIndicatorTest {
 
   @Test
   public void testServiceName() {
-    assertEquals(SERVICE_NAME, indicator.getServiceName());
+    assertEquals(SERVICE_NAME, indicator.mountUserFriendlyServiceName());
   }
 
   @Test

--- a/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/PodSessionManagerHealthIndicatorTest.java
+++ b/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/PodSessionManagerHealthIndicatorTest.java
@@ -48,7 +48,7 @@ public class PodSessionManagerHealthIndicatorTest {
 
   private static final String MOCK_VERSION = "1.48.0";
 
-  private static final String SERVICE_NAME = "Pod Session Manager";
+  private static final String SERVICE_NAME = ServiceName.POD_SESSION_MANAGER.toString();
 
   private static final String POD_SERVICE_NAME = ServiceName.POD.toString();
 

--- a/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/ServiceHealthIndicatorTest.java
+++ b/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/ServiceHealthIndicatorTest.java
@@ -90,7 +90,8 @@ public class ServiceHealthIndicatorTest {
 
   private Invocation.Builder invocationBuilder;
 
-  private MockApplicationPublisher<ServiceVersionUpdatedEventData> publisher = new MockApplicationPublisher<>();
+  private MockApplicationPublisher<ServiceVersionUpdatedEventData> publisher =
+      new MockApplicationPublisher<>();
 
   @Before
   public void init() {
@@ -113,12 +114,14 @@ public class ServiceHealthIndicatorTest {
 
   @Test
   public void testNullClient() {
-    doThrow(UnregisteredUserAuthException.class).when(authenticationProxy).httpClientForUser(anyString(), any(ServiceName.class));
+    doThrow(UnregisteredUserAuthException.class).when(authenticationProxy)
+        .httpClientForUser(anyString(), any(ServiceName.class));
 
     IntegrationBridgeService service = new IntegrationBridgeService(MOCK_VERSION, SERVICE_URL);
     service.setConnectivity(Status.DOWN);
 
-    Health expected = Health.down().withDetail(healthIndicator.getServiceName().toString(), service).build();
+    Health expected =
+        Health.down().withDetail(healthIndicator.mountUserFriendlyServiceName().toString(), service).build();
     Health result = healthIndicator.health();
 
     assertEquals(expected, result);
@@ -141,7 +144,8 @@ public class ServiceHealthIndicatorTest {
     IntegrationBridgeService service = new IntegrationBridgeService(MOCK_VERSION, SERVICE_URL);
     service.setConnectivity(Status.DOWN);
 
-    Health expected = Health.down().withDetail(healthIndicator.getServiceName().toString(), service).build();
+    Health expected =
+        Health.down().withDetail(healthIndicator.mountUserFriendlyServiceName(), service).build();
     Health result = healthIndicator.health();
 
     assertEquals(expected, result);
@@ -155,7 +159,8 @@ public class ServiceHealthIndicatorTest {
     IntegrationBridgeService service = new IntegrationBridgeService(MOCK_VERSION, SERVICE_URL);
     service.setConnectivity(Status.DOWN);
 
-    Health expected = Health.down().withDetail(healthIndicator.getServiceName().toString(), service).build();
+    Health expected =
+        Health.down().withDetail(healthIndicator.mountUserFriendlyServiceName(), service).build();
     Health result = healthIndicator.health();
 
     assertEquals(expected, result);
@@ -165,11 +170,15 @@ public class ServiceHealthIndicatorTest {
   public void testServiceUp() {
     mockServiceUp();
 
+    String expectedServiceName = StringUtils.lowerCase(MOCK_SERVICE_NAME.toString());
+    expectedServiceName = StringUtils.capitalize(expectedServiceName);
+
     IntegrationBridgeService service = new IntegrationBridgeService(MOCK_VERSION, SERVICE_URL);
     service.setConnectivity(Status.UP);
     service.setCurrentVersion(MOCK_CURRENT_VERSION);
 
-    Health expected = Health.up().withDetail(healthIndicator.getServiceName().toString(), service).build();
+    Health expected =
+        Health.up().withDetail(healthIndicator.mountUserFriendlyServiceName(), service).build();
     Health result = healthIndicator.health();
 
     assertEquals(expected, result);
@@ -179,7 +188,7 @@ public class ServiceHealthIndicatorTest {
 
     ServiceVersionUpdatedEventData event = publisher.getEvent();
     assertEquals(MOCK_CURRENT_SEMANTIC_VERSION, event.getNewVersion());
-    assertEquals(MOCK_SERVICE_NAME.toString(), event.getServiceName());
+    assertEquals(expectedServiceName, event.getServiceName());
     assertTrue(StringUtils.isEmpty(event.getOldVersion()));
   }
 
@@ -202,7 +211,8 @@ public class ServiceHealthIndicatorTest {
     IntegrationBridgeService service = new IntegrationBridgeService(MOCK_VERSION, SERVICE_URL);
     service.setConnectivity(Status.UP);
 
-    Health expected = Health.up().withDetail(healthIndicator.getServiceName().toString(), service).build();
+    Health expected =
+        Health.up().withDetail(healthIndicator.mountUserFriendlyServiceName(), service).build();
     Health result = healthIndicator.health();
 
     assertEquals(expected, result);
@@ -245,7 +255,8 @@ public class ServiceHealthIndicatorTest {
     ReflectionTestUtils.setField(healthIndicator, "serviceInfoCache", service);
     ReflectionTestUtils.setField(healthIndicator, "lastExecution", System.currentTimeMillis());
 
-    Health expected = Health.up().withDetail(healthIndicator.getServiceName().toString(), service).build();
+    Health expected =
+        Health.up().withDetail(healthIndicator.mountUserFriendlyServiceName(), service).build();
     Health result = healthIndicator.health();
 
     assertEquals(expected, result);

--- a/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/ServiceHealthIndicatorTest.java
+++ b/integration-healthcheck/src/test/java/org/symphonyoss/integration/healthcheck/services/ServiceHealthIndicatorTest.java
@@ -170,9 +170,6 @@ public class ServiceHealthIndicatorTest {
   public void testServiceUp() {
     mockServiceUp();
 
-    String expectedServiceName = StringUtils.lowerCase(MOCK_SERVICE_NAME.toString());
-    expectedServiceName = StringUtils.capitalize(expectedServiceName);
-
     IntegrationBridgeService service = new IntegrationBridgeService(MOCK_VERSION, SERVICE_URL);
     service.setConnectivity(Status.UP);
     service.setCurrentVersion(MOCK_CURRENT_VERSION);
@@ -188,7 +185,7 @@ public class ServiceHealthIndicatorTest {
 
     ServiceVersionUpdatedEventData event = publisher.getEvent();
     assertEquals(MOCK_CURRENT_SEMANTIC_VERSION, event.getNewVersion());
-    assertEquals(expectedServiceName, event.getServiceName());
+    assertEquals(ServiceName.POD.toString(), event.getServiceName());
     assertTrue(StringUtils.isEmpty(event.getOldVersion()));
   }
 


### PR DESCRIPTION
Both access the HC through the POD service, therefore its service name is POD. But to display the HC, each service must have different names, so a customization for the service name is now supported by overriding the method getFriendlyServiceName